### PR TITLE
gittalk id use md5(location.pathname)

### DIFF
--- a/templates/_blocks/scripts.ejs
+++ b/templates/_blocks/scripts.ejs
@@ -19,6 +19,7 @@ var app = new Vue({
   
   <% if (commentSetting.commentPlatform === 'gitalk') { %>
     <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-md5/2.10.0/js/md5.min.js"></script>
     <script>
 
       var gitalk = new Gitalk({
@@ -27,7 +28,7 @@ var app = new Vue({
         repo: '<%= commentSetting.gitalkSetting.repository %>',
         owner: '<%= commentSetting.gitalkSetting.owner %>',
         admin: ['<%= commentSetting.gitalkSetting.owner %>'],
-        id: location.pathname,      // Ensure uniqueness and length less than 50
+        id: md5(location.pathname),      // Ensure uniqueness and length less than 50
         distractionFreeMode: false  // Facebook-like distraction free mode
       })
 


### PR DESCRIPTION
在gridea中，默认的url为post的文件名称，如果是中文标题，经过编码之后，location.pathname很容易超过50个字符的情况。改变url则会改变post的文件名称，导致查找文件时不方便。所以使用md5进行加密，可解决。