### PR TITLE
update KaTeX and fix scroll bar between sidebar and main

### DIFF
--- a/assets/styles/main.less
+++ b/assets/styles/main.less
@@ -23,7 +23,7 @@ a {
   background-image: url('../media/images/sidebar-bg.jpg');
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
+//  overflow-y: scroll;
   .menu-btn {
     display: none;
   }

--- a/templates/index.ejs
+++ b/templates/index.ejs
@@ -4,7 +4,7 @@
     <%- include('./_blocks/head', { siteTitle: themeConfig.siteName }) %>
     <meta name="description" content="<%= themeConfig.siteDescription %>">
     <% if (site.customConfig.renderKaTeX) { %>
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css">
     <% } %>
   </head>
   <body>


### PR DESCRIPTION
1. update katex to its latest version 0.11.1, in which fixed a bug on displaying `\neq`  or `\not ` etc.
2. sidebar scroll disabled. fixed scroll bar between sidebar and main posts.