### PR TITLE
更换为 jsdelivr CDN

### DIFF
--- a/templates/_blocks/scripts.ejs
+++ b/templates/_blocks/scripts.ejs
@@ -13,7 +13,7 @@ var app = new Vue({
 </script>
 
 <% if (site.customConfig.renderCode) { %>
-  <script src="https://cdn.bootcss.com/highlight.js/9.12.0/highlight.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@highlightjs/cdn-assets/highlight.min.js"></script>
   <script>
     hljs.initHighlightingOnLoad()
   </script>


### PR DESCRIPTION
[现在这个](https://www.jsdelivr.com/package/npm/@highlightjs/cdn-assets) 和 bootcss 上的是一样的。